### PR TITLE
App/add app registerer

### DIFF
--- a/pymovebank/app/__main__.py
+++ b/pymovebank/app/__main__.py
@@ -4,10 +4,10 @@ import panel as pn
 # as the apps dict is defined. this is because
 # when the apps dict is imported, then it imports each app,
 # which registers them
-from pymovebank.app.apps import apps
+from pymovebank.app.apps import applications
 
 if __name__ == "__main__":
     pn.serve(
-        apps,
+        applications,
         port=5006
     )

--- a/pymovebank/app/__main__.py
+++ b/pymovebank/app/__main__.py
@@ -1,18 +1,13 @@
 import panel as pn
 
-from pymovebank.app.apps.tracks_explorer_app import view as tracks_explorer_app_view
-from pymovebank.app.apps.gridded_data_explorer_app import view as gridded_data_explorer_app_view
-from pymovebank.app.apps.subsetter_app import view as subsetter_app_view
-from pymovebank.app.apps.movie_maker_app import view as movie_maker_app_view
+# all registered apps need to be imported to the same folder
+# as the apps dict is defined. this is because
+# when the apps dict is imported, then it imports each app,
+# which registers them
+from pymovebank.app.apps import apps
 
 if __name__ == "__main__":
-
     pn.serve(
-        {
-            "tracks_explorer_app": tracks_explorer_app_view,
-            "gridded_data_explorer_app": gridded_data_explorer_app_view,
-            "subsetter_app": subsetter_app_view,
-            "movie_maker_app": movie_maker_app_view,
-        },
+        apps,
         port=5006
     )

--- a/pymovebank/app/apps/__init__.py
+++ b/pymovebank/app/apps/__init__.py
@@ -1,7 +1,7 @@
 # all registered apps need to be imported here. this is because
 # when the apps dict is imported, then it imports each app,
 # which registers them
-apps = {}
+applications = {}
 
 import pymovebank.app.apps.tracks_explorer_app
 import pymovebank.app.apps.gridded_data_explorer_app

--- a/pymovebank/app/apps/__init__.py
+++ b/pymovebank/app/apps/__init__.py
@@ -1,0 +1,9 @@
+# all registered apps need to be imported here. this is because
+# when the apps dict is imported, then it imports each app,
+# which registers them
+apps = {}
+
+import pymovebank.app.apps.tracks_explorer_app
+import pymovebank.app.apps.gridded_data_explorer_app
+import pymovebank.app.apps.subsetter_app
+import pymovebank.app.apps.movie_maker_app

--- a/pymovebank/app/apps/gridded_data_explorer_app.py
+++ b/pymovebank/app/apps/gridded_data_explorer_app.py
@@ -29,9 +29,9 @@ from pathlib import Path
 from panel.reactive import ReactiveHTML, Viewable
 
 from pymovebank.plotting import plot_gridded_data, plot_avg_timeseries
-from pymovebank.panel_utils import param_widget, try_catch
+from pymovebank.panel_utils import param_widget, try_catch, templater
 from pymovebank.xr_tools import detect_varnames
-from pymovebank.app.models import config
+from pymovebank.app import config
 
 
 class HTML_WidgetBox(ReactiveHTML):
@@ -539,6 +539,14 @@ def view():
     template.main.append(viewer.figs_with_widget)
     template.main.append(viewer.view)
     return template
+
+
+@config.register_view()
+def view(app):
+    viewer = GriddedDataExplorer()
+    return templater(app.template, main=[viewer.figs_with_widget, viewer.view], sidebar=[viewer.sidebar])
+
+
 
 
 if __name__ == "__main__":

--- a/pymovebank/app/apps/gridded_data_explorer_app.py
+++ b/pymovebank/app/apps/gridded_data_explorer_app.py
@@ -532,15 +532,6 @@ class GriddedDataExplorer(param.Parameterized):
         self.status_text = f'File saved to: {outfile}'
 
 
-def view():
-    _, template = config.extension('tabulator', url="gridded_data_explorer_app")
-    viewer = GriddedDataExplorer()
-    template.sidebar.append(viewer.sidebar)
-    template.main.append(viewer.figs_with_widget)
-    template.main.append(viewer.view)
-    return template
-
-
 @config.register_view()
 def view(app):
     viewer = GriddedDataExplorer()

--- a/pymovebank/app/apps/home.py
+++ b/pymovebank/app/apps/home.py
@@ -2,7 +2,8 @@
 # pylint: disable=wrong-import-position, ungrouped-imports, wrong-import-order
 import panel as pn
 
-from pymovebank.app.models import config
+from pymovebank.app import config
+from pymovebank.panel_utils import templater
 
 # pylint: enable=wrong-import-position, ungrouped-imports, wrong-import-order
 
@@ -11,14 +12,13 @@ def _add_sections():
     pn.pane.Markdown("# Home page test!").servable()
 
 
-def view():
-    _, template = config.extension('tabulator', url="gridded_data_explorer_app")
+@config.register_view()
+def view(app):
+    return templater(app.template, main=[pn.pane.Markdown("# Select an App on the Left")])
 
-    template.main.append(pn.pane.Markdown("# Select an App on the Left"))
-    template.servable()
-    return template
+if __name__ == "__main__":
+    pn.serve({"home": view})
 
-if __name__ == "__main__" or __name__.startswith("bokeh"):
-    config.extension(url="home", main_max_width="900px", intro_section=False)
 
-    _add_sections()
+if __name__.startswith("bokeh"):
+    view()

--- a/pymovebank/app/apps/movie_maker_app.py
+++ b/pymovebank/app/apps/movie_maker_app.py
@@ -7,8 +7,8 @@ import panel as pn
 
 import param
 from panel.io.loading import start_loading_spinner, stop_loading_spinner
-from pymovebank.panel_utils import param_widget
-from pymovebank.app.models import config
+from pymovebank.panel_utils import param_widget, templater
+from pymovebank.app import config
 
 # from holoviews.operation.datashader import datashade, shade, dynspread, spread
 
@@ -84,13 +84,9 @@ class MovieMaker(param.Parameterized):
             stop_loading_spinner(self.view)
 
 
-def view():
-    _, template = config.extension(url="movie_maker_app")
-    viewer = MovieMaker()
-
-    template.main.append(viewer.view)
-    return template
-
+@config.register_view()
+def view(app):
+    return templater(app.template, main=[MovieMaker().view])
 
 if __name__ == "__main__":
     pn.serve({"movie_maker_app": view})

--- a/pymovebank/app/apps/subsetter_app.py
+++ b/pymovebank/app/apps/subsetter_app.py
@@ -21,8 +21,8 @@ import panel as pn
 
 import param
 from panel.io.loading import start_loading_spinner, stop_loading_spinner
-from pymovebank.panel_utils import param_widget, try_catch
-from pymovebank.app.models import config
+from pymovebank.panel_utils import param_widget, try_catch, templater
+from pymovebank.app import config
 
 # from holoviews.operation.datashader import datashade, shade, dynspread, spread
 
@@ -191,12 +191,10 @@ class Subsetter(param.Parameterized):
             stop_loading_spinner(self.view)
 
 
-def view():
-    _, template = config.extension('tabulator', url="subsetter_app")
+@config.register_view()
+def view(app):
     viewer = Subsetter()
-
-    template.main.append(viewer.view)
-    return template
+    return templater(app.template, main=[viewer.view])
 
 
 if __name__ == "__main__":

--- a/pymovebank/app/apps/tracks_explorer_app.py
+++ b/pymovebank/app/apps/tracks_explorer_app.py
@@ -35,9 +35,9 @@ from pathlib import Path
 
 import pymovebank as pmv
 from pymovebank.plotting import map_tile_options, plot_tracks_with_tiles
-from pymovebank.panel_utils import select_file, select_output, param_widget, try_catch
-from pymovebank.app.models import config
-from pymovebank.app.models.models import PMVCard, FileSelector
+from pymovebank.panel_utils import param_widget, try_catch, templater
+from pymovebank.app import config
+from pymovebank.app.models import PMVCard, FileSelector
 
 # from panel_jstree.widgets.jstree import FileTree
 
@@ -228,13 +228,10 @@ class TracksExplorer(param.Parameterized):
         self.status_text = "Plot created!"
 
 
-def view():
-    _, template = config.extension(url="tracks_explorer_app")
+@config.register_view()
+def view(app):
     viewer = TracksExplorer()
-
-    template.sidebar.append(viewer.options_col)
-    template.main.append(viewer.view)
-    return template
+    return templater(app.template, main=[viewer.view], sidebar=[viewer.options_col])
 
 
 if __name__ == "__main__":

--- a/pymovebank/app/config.py
+++ b/pymovebank/app/config.py
@@ -1,7 +1,9 @@
 """Shared configuration and functionality for awesome_panel apps"""
 from functools import wraps
+from pathlib import Path
 from typing import Optional, Union
 from urllib.parse import urlsplit
+import inspect
 
 import panel as pn
 from awesome_panel_extensions.site.gallery import GalleryTemplate
@@ -9,6 +11,7 @@ from awesome_panel_extensions.site.models import Application
 from panel.template import FastGridTemplate, FastListTemplate, GoldenTemplate
 
 from pymovebank.app.assets import menu_fast_html, list_links_html, APPLICATIONS_CONFIG_PATH, FAST_CSS, FAST_CSS_PATH
+from pymovebank.app.apps import apps
 
 SITE = "Movement Data Aggregator"
 
@@ -72,6 +75,24 @@ for _template in _TEMPLATES:
         _template.param.header_background.default = ACCENT
         _template.param.sidebar_footer.default = menu_fast_html(accent=ACCENT, jinja_subs=list_html)
 
+
+# all registered apps need to be imported to the same folder
+# as the apps dict is defined. this is because
+# when the apps dict is imported, then it imports each app,
+# which registers them
+def register_view(*ext_args, url=None, **ext_kw):
+    url = url or Path(inspect.stack()[1].filename).stem  # file name of calling file
+    def inner(view):
+        @wraps(view)
+        def wrapped_app(*args, **kwargs):
+            app = extension(url=url, *ext_args, **ext_kw)
+
+            return view(app, *args, **kwargs)
+        apps[url] = wrapped_app
+        return wrapped_app
+    return inner
+
+
 def extension(
     *args,
     url,
@@ -131,4 +152,6 @@ def extension(
     # if intro_section and template not in [pn.template.FastGridTemplate]:
     #     app.intro_section().servable()
 
-    return app, template
+    app.template = template
+
+    return app

--- a/pymovebank/app/config.py
+++ b/pymovebank/app/config.py
@@ -11,7 +11,7 @@ from awesome_panel_extensions.site.models import Application
 from panel.template import FastGridTemplate, FastListTemplate, GoldenTemplate
 
 from pymovebank.app.assets import menu_fast_html, list_links_html, APPLICATIONS_CONFIG_PATH, FAST_CSS, FAST_CSS_PATH
-from pymovebank.app.apps import apps
+from pymovebank.app.apps import applications
 
 SITE = "Movement Data Aggregator"
 
@@ -88,7 +88,7 @@ def register_view(*ext_args, url=None, **ext_kw):
             app = extension(url=url, *ext_args, **ext_kw)
 
             return view(app, *args, **kwargs)
-        apps[url] = wrapped_app
+        applications[url] = wrapped_app
         return wrapped_app
     return inner
 

--- a/pymovebank/app/models.py
+++ b/pymovebank/app/models.py
@@ -19,7 +19,7 @@ from typing import (
 import param
 import panel as pn
 
-from pymovebank.app.models import config
+from pymovebank.app import config
 
 
 class PMVCard(pn.Card):

--- a/pymovebank/panel_utils.py
+++ b/pymovebank/panel_utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import param
 import panel as pn
 import functools
@@ -6,8 +7,12 @@ import subprocess
 import os
 import shlex
 from pathlib import Path
+from typing import Callable, Sequence, Union
 
 from tkinter import Tk, filedialog
+
+Servable = Union[Callable, pn.viewable.Viewable]
+
 IS_WINDOWS = os.name == "nt"
 
 logger = logging.getLogger(__file__)
@@ -104,3 +109,21 @@ def make_mp4_from_frames(frames_dir, output_file, frame_rate):
     -c:v libx264 -pix_fmt yuv420p -y {output_file}"""
 
     subprocess.run(split_shell_command(cmd))
+
+def templater(
+        template: pn.template.BaseTemplate,
+        main: Servable | Sequence[Servable] = (),
+        sidebar: Servable | Sequence[Servable] = (),
+        header: Servable | Sequence[Servable] = (),
+):
+    main = main if isinstance(main, Sequence) else [main]
+    sidebar = sidebar if isinstance(sidebar, Sequence) else [sidebar]
+    header = header if isinstance(header, Sequence) else [header]
+    for app in main:
+        template.main.append(app)
+    for app in sidebar:
+        template.sidebar.append(app)
+    for app in header:
+        template.header.append(app)
+
+    return template

--- a/pymovebank/tests/conftest.py
+++ b/pymovebank/tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+import panel as pn
+from pymovebank.app.apps import applications
+
+
+PORT = [6000]
+
+
+@pytest.fixture
+def port():
+    PORT[0] += 1
+    return PORT[0]
+
+
+@pytest.fixture
+def apps():
+    return applications
+
+
+@pytest.fixture()
+def serve_apps(port, apps):
+    server = pn.serve(apps, port=port, threaded=True, show=False)
+    yield server
+    try:
+        server.stop()
+    except AssertionError:
+        pass  # tests may already close this

--- a/pymovebank/tests/test_apps.py
+++ b/pymovebank/tests/test_apps.py
@@ -1,0 +1,10 @@
+import requests
+
+
+def test_server_has_every_app(serve_apps, port, apps):
+    for app in apps:
+        r = requests.get(f"http://localhost:{port}/{app}")
+        assert 200 <= int(r.status_code) <= 299
+
+
+# TODO you could add tests using playwright to doing ui browser testing?


### PR DESCRIPTION
# Summary
- [Add register_view func to register apps for convenience](https://github.com/jemissik/pymovebank/commit/744b54963d3a27477406fb765e71499c35234876)
  Add a register_view decorator that can be applied to a view function
  of an app. It adds it a global dictionary that can be imported and
  served all at once. This is convenient b/c instead of having to
  import all of the apps anywher you want to serve them (dunder main, tests, etc)
  you can just import this dict.
  
  Also added a templater convenience function to make it easier
  to template a view
- [add a simple app integration test that just tests if the apps serve with a 2## status code or not](https://github.com/jemissik/pymovebank/commit/f8612a4c3fd40dc397d6e462233dad94d79f663b) 