### PR TITLE
Move applications import to avoid circular import on direct app serve

### DIFF
--- a/pymovebank/app/__main__.py
+++ b/pymovebank/app/__main__.py
@@ -1,7 +1,7 @@
 import panel as pn
 
 # all registered apps need to be imported to the same folder
-# as the apps dict is defined. this is because
+# as the applications is imported from. this is because
 # when the apps dict is imported, then it imports each app,
 # which registers them
 from pymovebank.app.apps import applications

--- a/pymovebank/app/apps/__init__.py
+++ b/pymovebank/app/apps/__init__.py
@@ -1,9 +1,6 @@
-# all registered apps need to be imported here. this is because
-# when the apps dict is imported, then it imports each app,
-# which registers them
-applications = {}
-
 import pymovebank.app.apps.tracks_explorer_app
 import pymovebank.app.apps.gridded_data_explorer_app
 import pymovebank.app.apps.subsetter_app
 import pymovebank.app.apps.movie_maker_app
+
+from pymovebank.panel_utils import applications  # noqa

--- a/pymovebank/app/apps/gridded_data_explorer_app.py
+++ b/pymovebank/app/apps/gridded_data_explorer_app.py
@@ -29,9 +29,8 @@ from pathlib import Path
 from panel.reactive import ReactiveHTML, Viewable
 
 from pymovebank.plotting import plot_gridded_data, plot_avg_timeseries
-from pymovebank.panel_utils import param_widget, try_catch, templater
+from pymovebank.panel_utils import param_widget, try_catch, templater, register_view
 from pymovebank.xr_tools import detect_varnames
-from pymovebank.app import config
 
 
 class HTML_WidgetBox(ReactiveHTML):
@@ -532,7 +531,7 @@ class GriddedDataExplorer(param.Parameterized):
         self.status_text = f'File saved to: {outfile}'
 
 
-@config.register_view()
+@register_view()
 def view(app):
     viewer = GriddedDataExplorer()
     return templater(app.template, main=[viewer.figs_with_widget, viewer.view], sidebar=[viewer.sidebar])

--- a/pymovebank/app/apps/home.py
+++ b/pymovebank/app/apps/home.py
@@ -2,8 +2,7 @@
 # pylint: disable=wrong-import-position, ungrouped-imports, wrong-import-order
 import panel as pn
 
-from pymovebank.app import config
-from pymovebank.panel_utils import templater
+from pymovebank.panel_utils import templater, register_view
 
 # pylint: enable=wrong-import-position, ungrouped-imports, wrong-import-order
 
@@ -12,7 +11,7 @@ def _add_sections():
     pn.pane.Markdown("# Home page test!").servable()
 
 
-@config.register_view()
+@register_view()
 def view(app):
     return templater(app.template, main=[pn.pane.Markdown("# Select an App on the Left")])
 

--- a/pymovebank/app/apps/movie_maker_app.py
+++ b/pymovebank/app/apps/movie_maker_app.py
@@ -7,12 +7,10 @@ import panel as pn
 
 import param
 from panel.io.loading import start_loading_spinner, stop_loading_spinner
-from pymovebank.panel_utils import param_widget, templater
-from pymovebank.app import config
-
-# from holoviews.operation.datashader import datashade, shade, dynspread, spread
+from pymovebank.panel_utils import param_widget, templater, register_view
 
 logger = logging.getLogger(__file__)
+
 
 class MovieMaker(param.Parameterized):
 
@@ -84,7 +82,7 @@ class MovieMaker(param.Parameterized):
             stop_loading_spinner(self.view)
 
 
-@config.register_view()
+@register_view()
 def view(app):
     return templater(app.template, main=[MovieMaker().view])
 

--- a/pymovebank/app/apps/subsetter_app.py
+++ b/pymovebank/app/apps/subsetter_app.py
@@ -21,14 +21,11 @@ import panel as pn
 
 import param
 from panel.io.loading import start_loading_spinner, stop_loading_spinner
-from pymovebank.panel_utils import param_widget, try_catch, templater
-from pymovebank.app import config
-
-# from holoviews.operation.datashader import datashade, shade, dynspread, spread
+from pymovebank.panel_utils import param_widget, try_catch, templater, register_view
 
 logger = logging.getLogger(__file__)
 
-# %% pycharm={"name": "#%%\n"}
+
 class Subsetter(param.Parameterized):
 
     # Input GIS file
@@ -191,7 +188,7 @@ class Subsetter(param.Parameterized):
             stop_loading_spinner(self.view)
 
 
-@config.register_view()
+@register_view()
 def view(app):
     viewer = Subsetter()
     return templater(app.template, main=[viewer.view])

--- a/pymovebank/app/apps/tracks_explorer_app.py
+++ b/pymovebank/app/apps/tracks_explorer_app.py
@@ -35,14 +35,12 @@ from pathlib import Path
 
 import pymovebank as pmv
 from pymovebank.plotting import map_tile_options, plot_tracks_with_tiles
-from pymovebank.panel_utils import param_widget, try_catch, templater
-from pymovebank.app import config
+from pymovebank.panel_utils import param_widget, try_catch, templater, register_view
 from pymovebank.app.models import PMVCard, FileSelector
 
 # from panel_jstree.widgets.jstree import FileTree
 
 
-# %%
 class TracksExplorer(param.Parameterized):
 
     load_tracks_button = param_widget(pn.widgets.Button(button_type='primary', name='Load data'))
@@ -228,7 +226,7 @@ class TracksExplorer(param.Parameterized):
         self.status_text = "Plot created!"
 
 
-@config.register_view()
+@register_view()
 def view(app):
     viewer = TracksExplorer()
     return templater(app.template, main=[viewer.view], sidebar=[viewer.options_col])

--- a/pymovebank/app/config.py
+++ b/pymovebank/app/config.py
@@ -1,9 +1,8 @@
 """Shared configuration and functionality for awesome_panel apps"""
-from functools import wraps
-from pathlib import Path
+
 from typing import Optional, Union
 from urllib.parse import urlsplit
-import inspect
+
 
 import panel as pn
 from awesome_panel_extensions.site.gallery import GalleryTemplate
@@ -73,24 +72,6 @@ for _template in _TEMPLATES:
     if not _template == GalleryTemplate:
         _template.param.header_background.default = ACCENT
         _template.param.sidebar_footer.default = menu_fast_html(accent=ACCENT, jinja_subs=list_html)
-
-
-# all registered apps need to be imported to the same folder
-# as the apps dict is defined. this is because
-# when the apps dict is imported, then it imports each app,
-# which registers them
-def register_view(*ext_args, url=None, **ext_kw):
-    from pymovebank.app.apps import applications
-    url = url or Path(inspect.stack()[1].filename).stem  # file name of calling file
-    def inner(view):
-        @wraps(view)
-        def wrapped_app(*args, **kwargs):
-            app = extension(url=url, *ext_args, **ext_kw)
-
-            return view(app, *args, **kwargs)
-        applications[url] = wrapped_app
-        return wrapped_app
-    return inner
 
 
 def extension(

--- a/pymovebank/app/config.py
+++ b/pymovebank/app/config.py
@@ -11,7 +11,6 @@ from awesome_panel_extensions.site.models import Application
 from panel.template import FastGridTemplate, FastListTemplate, GoldenTemplate
 
 from pymovebank.app.assets import menu_fast_html, list_links_html, APPLICATIONS_CONFIG_PATH, FAST_CSS, FAST_CSS_PATH
-from pymovebank.app.apps import applications
 
 SITE = "Movement Data Aggregator"
 
@@ -81,6 +80,7 @@ for _template in _TEMPLATES:
 # when the apps dict is imported, then it imports each app,
 # which registers them
 def register_view(*ext_args, url=None, **ext_kw):
+    from pymovebank.app.apps import applications
     url = url or Path(inspect.stack()[1].filename).stem  # file name of calling file
     def inner(view):
         @wraps(view)


### PR DESCRIPTION
when serving an app directly (ex: panel serve path/to/app) having applications imported in config at the top level led to a circular import moving it to being defined in register_view fixes this.