### PR TITLE
Fix bug where changing apps bleed into each other

### DIFF
--- a/pymovebank/app/__main__.py
+++ b/pymovebank/app/__main__.py
@@ -8,6 +8,6 @@ from pymovebank.app.apps import applications
 
 if __name__ == "__main__":
     pn.serve(
-        {url: app.view for url, app in applications.items()},
+        {url: view for url, view in applications.items()},
         port=5006
     )

--- a/pymovebank/app/apps/gridded_data_explorer_app.py
+++ b/pymovebank/app/apps/gridded_data_explorer_app.py
@@ -531,7 +531,7 @@ class GriddedDataExplorer(param.Parameterized):
         self.status_text = f'File saved to: {outfile}'
 
 
-@register_view(app=Application.from_filename())
+@register_view()
 def view(app):
     viewer = GriddedDataExplorer()
     return templater(app.template, main=[viewer.figs_with_widget, viewer.view], sidebar=[viewer.sidebar])

--- a/pymovebank/app/apps/movie_maker_app.py
+++ b/pymovebank/app/apps/movie_maker_app.py
@@ -85,7 +85,7 @@ class MovieMaker(param.Parameterized):
             stop_loading_spinner(self.view)
 
 
-@register_view(app=Application.from_filename())
+@register_view()
 def view(app):
     return templater(app.template, main=[MovieMaker().view])
 

--- a/pymovebank/app/apps/subsetter_app.py
+++ b/pymovebank/app/apps/subsetter_app.py
@@ -189,7 +189,7 @@ class Subsetter(param.Parameterized):
             stop_loading_spinner(self.view)
 
 
-@register_view(app=Application.from_filename())
+@register_view()
 def view(app):
     viewer = Subsetter()
     return templater(app.template, main=[viewer.view])

--- a/pymovebank/app/apps/tracks_explorer_app.py
+++ b/pymovebank/app/apps/tracks_explorer_app.py
@@ -227,7 +227,7 @@ class TracksExplorer(param.Parameterized):
         self.status_text = "Plot created!"
 
 
-@register_view(app=Application.from_filename())
+@register_view()
 def view(app):
     viewer = TracksExplorer()
     return templater(app.template, main=[viewer.view], sidebar=[viewer.options_col])


### PR DESCRIPTION
Apps would bleed into each other when changing apps becuase the apps were defined once at definition time And then at run time their different sections were appeneded to. This results in the sections from each app just appearing below the previous app when you switch apps. This is fixed by modify the register_view decorator to still define the links at definition time, so that all apps have the same links (If the links were created at run time, you would have to run an app before the link for that app was added to the links sections), but the apps themselves are created fresh each time they are clicked on. This ensures that each app is new and each section of the app is blank when it is created, so no bleed over effect is encountered.